### PR TITLE
全体画面の追加と画面切替タブ実装 (#2)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "bingo-app",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", "-l", "3333", "."],
+      "port": 3333
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -9,14 +9,13 @@
 <body>
     <div class="container">
         <header>
+            <div class="view-tabs">
+                <button id="tabHistory" class="tab-button tab-active">履歴画面</button>
+                <button id="tabOverview" class="tab-button">全体画面</button>
+            </div>
             <h1>ビンゴ抽選器</h1>
             <button id="settingsButton" class="settings-button">⚙️ 設定</button>
         </header>
-        
-        <div class="view-tabs">
-            <button id="tabHistory" class="tab-button tab-active">履歴画面</button>
-            <button id="tabOverview" class="tab-button">全体画面</button>
-        </div>
 
         <main id="viewHistory" class="view-panel">
             <div class="lottery-area">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,12 @@
             <button id="settingsButton" class="settings-button">⚙️ 設定</button>
         </header>
         
-        <main>
+        <div class="view-tabs">
+            <button id="tabHistory" class="tab-button tab-active">履歴画面</button>
+            <button id="tabOverview" class="tab-button">全体画面</button>
+        </div>
+
+        <main id="viewHistory" class="view-panel">
             <div class="lottery-area">
                 <div class="current-number">
                     <h2>現在の番号</h2>
@@ -21,13 +26,22 @@
                     <button id="drawButton" class="draw-button">抽選開始</button>
                 </div>
             </div>
-            
+
             <div class="history-area">
                 <h2>抽選履歴</h2>
                 <div id="historyList" class="history-list">
                     <p class="no-history">まだ抽選されていません</p>
                 </div>
                 <button id="resetButton" class="reset-button">リセット</button>
+            </div>
+        </main>
+
+        <main id="viewOverview" class="view-panel view-hidden">
+            <div class="overview-area">
+                <h2>番号一覧（01〜75）</h2>
+                <p class="overview-stats" id="overviewStats">抽選済み：0 / 75</p>
+                <div id="overviewGrid" class="overview-grid"></div>
+                <button id="resetButtonOverview" class="reset-button overview-reset-button">リセット</button>
             </div>
         </main>
         

--- a/script.js
+++ b/script.js
@@ -9,6 +9,15 @@ class BingoLottery {
         this.drawButton = document.getElementById('drawButton');
         this.resetButton = document.getElementById('resetButton');
         this.historyList = document.getElementById('historyList');
+
+        // タブ・全体画面関連の要素
+        this.tabHistory = document.getElementById('tabHistory');
+        this.tabOverview = document.getElementById('tabOverview');
+        this.viewHistory = document.getElementById('viewHistory');
+        this.viewOverview = document.getElementById('viewOverview');
+        this.overviewGrid = document.getElementById('overviewGrid');
+        this.overviewStats = document.getElementById('overviewStats');
+        this.resetButtonOverview = document.getElementById('resetButtonOverview');
         
         // 設定関連の要素
         this.settingsButton = document.getElementById('settingsButton');
@@ -25,14 +34,20 @@ class BingoLottery {
         this.slowdownMaxInput = document.getElementById('slowdownMax');
         
         this.initializeEventListeners();
-        this.loadFromStorage(); // localStorageから履歴を読み込み
-        this.loadSettings(); // 設定を読み込み
+        this.loadFromStorage();
+        this.loadSettings();
         this.updateDisplay();
+        this.buildOverviewGrid();
     }
     
     initializeEventListeners() {
         this.drawButton.addEventListener('click', () => this.startRoulette());
         this.resetButton.addEventListener('click', () => this.reset());
+        this.resetButtonOverview.addEventListener('click', () => this.reset());
+
+        // タブ切替
+        this.tabHistory.addEventListener('click', () => this.switchTab('history'));
+        this.tabOverview.addEventListener('click', () => this.switchTab('overview'));
         
         // 設定関連のイベントリスナー
         this.settingsButton.addEventListener('click', () => this.openSettings());
@@ -244,17 +259,15 @@ class BingoLottery {
     }
     
     updateDisplay() {
-        // 現在の番号を表示
         if (this.currentNumber) {
             this.currentNumberElement.textContent = this.currentNumber.toString().padStart(2, '0');
         } else {
             this.currentNumberElement.textContent = '-';
         }
-        
-        // 履歴を更新
+
         this.updateHistory();
-        
-        // ボタンの状態を更新（スピン中でない場合のみ）
+        this.updateOverviewGrid();
+
         if (!this.isSpinning) {
             this.drawButton.disabled = this.numbers.length === 0;
         }
@@ -290,9 +303,54 @@ class BingoLottery {
             this.drawButton.disabled = false;
             this.drawButton.textContent = '抽選開始';
             this.updateDisplay();
-            
-            // localStorageを削除
             this.deleteFromStorage();
+        }
+    }
+
+    switchTab(tab) {
+        if (tab === 'history') {
+            this.viewHistory.classList.remove('view-hidden');
+            this.viewOverview.classList.add('view-hidden');
+            this.tabHistory.classList.add('tab-active');
+            this.tabOverview.classList.remove('tab-active');
+        } else {
+            this.viewHistory.classList.add('view-hidden');
+            this.viewOverview.classList.remove('view-hidden');
+            this.tabHistory.classList.remove('tab-active');
+            this.tabOverview.classList.add('tab-active');
+        }
+    }
+
+    buildOverviewGrid() {
+        this.overviewGrid.innerHTML = '';
+        for (let i = 1; i <= 75; i++) {
+            const cell = document.createElement('div');
+            cell.className = 'overview-cell';
+            cell.id = `cell-${i}`;
+            cell.textContent = i.toString().padStart(2, '0');
+            this.overviewGrid.appendChild(cell);
+        }
+        this.updateOverviewGrid();
+    }
+
+    updateOverviewGrid() {
+        if (!this.overviewGrid) return;
+        for (let i = 1; i <= 75; i++) {
+            const cell = document.getElementById(`cell-${i}`);
+            if (!cell) continue;
+            if (this.drawnNumbers.includes(i)) {
+                cell.classList.add('overview-cell-drawn');
+                if (i === this.currentNumber) {
+                    cell.classList.add('overview-cell-latest');
+                } else {
+                    cell.classList.remove('overview-cell-latest');
+                }
+            } else {
+                cell.classList.remove('overview-cell-drawn', 'overview-cell-latest');
+            }
+        }
+        if (this.overviewStats) {
+            this.overviewStats.textContent = `抽選済み：${this.drawnNumbers.length} / 75`;
         }
     }
     

--- a/style.css
+++ b/style.css
@@ -12,9 +12,9 @@ body {
 }
 
 .container {
-    max-width: 1200px;
+    max-width: 1600px;
     margin: 0 auto;
-    padding: 20px;
+    padding: 30px;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -22,15 +22,15 @@ body {
 
 header {
     text-align: center;
-    margin-bottom: 40px;
+    margin-bottom: 50px;
     position: relative;
 }
 
 header h1 {
     color: white;
-    font-size: 2.5rem;
+    font-size: 3.5rem;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-    margin-bottom: 10px;
+    margin-bottom: 15px;
 }
 
 .settings-button {
@@ -40,10 +40,10 @@ header h1 {
     background: rgba(255, 255, 255, 0.2);
     color: white;
     border: 2px solid rgba(255, 255, 255, 0.3);
-    padding: 8px 16px;
-    border-radius: 20px;
+    padding: 12px 20px;
+    border-radius: 25px;
     cursor: pointer;
-    font-size: 1rem;
+    font-size: 1.2rem;
     transition: all 0.3s ease;
     backdrop-filter: blur(10px);
 }
@@ -56,12 +56,12 @@ header h1 {
 
 main {
     display: flex;
-    gap: 40px;
+    gap: 50px;
     flex: 1;
 }
 
 .lottery-area {
-    flex: 2;
+    flex: 0 0 30%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -70,47 +70,47 @@ main {
 .current-number {
     text-align: center;
     background: white;
-    padding: 40px;
-    border-radius: 20px;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-    min-width: 300px;
+    padding: 50px;
+    border-radius: 25px;
+    box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+    width: 100%;
 }
 
 .current-number h2 {
     color: #667eea;
-    margin-bottom: 20px;
-    font-size: 1.5rem;
+    margin-bottom: 30px;
+    font-size: 2rem;
 }
 
 .number-display {
-    font-size: 8rem;
+    font-size: 20rem;
     font-weight: bold;
     color: #764ba2;
-    margin: 30px 0;
-    min-height: 80px;
+    margin: 40px 0;
+    min-height: 100px;
     display: flex;
     align-items: center;
     justify-content: center;
     background: linear-gradient(45deg, #f0f0f0, #e0e0e0);
-    border-radius: 15px;
-    border: 3px solid #667eea;
+    border-radius: 20px;
+    border: 4px solid #667eea;
 }
 
 .draw-button {
     background: linear-gradient(45deg, #667eea, #764ba2);
     color: white;
     border: none;
-    padding: 15px 30px;
-    font-size: 1.2rem;
-    border-radius: 25px;
+    padding: 20px 40px;
+    font-size: 1.5rem;
+    border-radius: 30px;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.2);
 }
 
 .draw-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 7px 20px rgba(0,0,0,0.3);
+    transform: translateY(-3px);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.3);
 }
 
 .draw-button:disabled {
@@ -121,28 +121,27 @@ main {
 }
 
 .history-area {
-    flex: 1;
+    flex: 0 0 70%;
     background: white;
-    padding: 30px;
-    border-radius: 20px;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-    max-height: 600px;
+    padding: 40px;
+    border-radius: 25px;
+    box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+    max-height: 800px;
     overflow-y: auto;
-    min-width: 400px;
 }
 
 .history-area h2 {
     color: #667eea;
-    margin-bottom: 20px;
+    margin-bottom: 30px;
     text-align: center;
-    font-size: 1.5rem;
+    font-size: 2rem;
 }
 
 .history-list {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
     width: 100%;
 }
 
@@ -151,25 +150,27 @@ main {
     color: #999;
     font-style: italic;
     grid-column: 1 / -1;
+    font-size: 1.2rem;
 }
 
 .history-item {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 12px 8px;
+    padding: 15px 10px;
     background: #f8f9fa;
-    border-radius: 8px;
-    border-left: 3px solid #667eea;
+    border-radius: 12px;
+    border-left: 4px solid #667eea;
     text-align: center;
-    min-height: 60px;
+    min-height: 100px;
     word-break: keep-all;
+    aspect-ratio: 1;
 }
 
 .history-number {
     font-weight: bold;
     color: #764ba2;
-    font-size: 1.8rem;
+    font-size: clamp(2rem, 8vw, 7rem);
     line-height: 1;
 }
 
@@ -178,23 +179,24 @@ main {
     background: #dc3545;
     color: white;
     border: none;
-    padding: 12px;
-    border-radius: 10px;
+    padding: 15px;
+    border-radius: 15px;
     cursor: pointer;
     transition: all 0.3s ease;
-    font-size: 1rem;
+    font-size: 1.2rem;
 }
 
 .reset-button:hover {
     background: #c82333;
-    transform: translateY(-1px);
+    transform: translateY(-2px);
 }
 
 footer {
     text-align: center;
-    margin-top: 40px;
+    margin-top: 50px;
     color: white;
     opacity: 0.8;
+    font-size: 1.1rem;
 }
 
 /* アニメーション */

--- a/style.css
+++ b/style.css
@@ -199,6 +199,128 @@ footer {
     font-size: 1.1rem;
 }
 
+/* タブ */
+.view-tabs {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-bottom: 30px;
+}
+
+.tab-button {
+    background: rgba(255, 255, 255, 0.2);
+    color: white;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    padding: 12px 36px;
+    border-radius: 25px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+}
+
+.tab-button:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.tab-button.tab-active {
+    background: white;
+    color: #764ba2;
+    border-color: white;
+    font-weight: bold;
+}
+
+/* 画面切替 */
+.view-panel {
+    display: flex;
+    gap: 50px;
+    flex: 1;
+}
+
+.view-hidden {
+    display: none !important;
+}
+
+/* 全体画面 */
+.overview-area {
+    flex: 1;
+    background: white;
+    padding: 40px;
+    border-radius: 25px;
+    box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+}
+
+.overview-area h2 {
+    color: #667eea;
+    text-align: center;
+    font-size: 2rem;
+    margin-bottom: 12px;
+}
+
+.overview-stats {
+    text-align: center;
+    color: #764ba2;
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin-bottom: 30px;
+}
+
+.overview-grid {
+    display: grid;
+    grid-template-columns: repeat(10, 1fr);
+    gap: 10px;
+    margin-bottom: 30px;
+}
+
+.overview-cell {
+    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px;
+    font-size: clamp(1rem, 2vw, 1.6rem);
+    font-weight: bold;
+    background: #f0f0f0;
+    color: #555;
+    border: 2px solid #ddd;
+    transition: all 0.3s ease;
+}
+
+.overview-cell-drawn {
+    background: linear-gradient(45deg, #667eea, #764ba2);
+    color: white;
+    border-color: #667eea;
+}
+
+.overview-cell-latest {
+    background: linear-gradient(45deg, #f093fb, #f5576c);
+    border-color: #f5576c;
+    transform: scale(1.1);
+    box-shadow: 0 4px 12px rgba(245, 87, 108, 0.5);
+}
+
+.overview-reset-button {
+    margin-top: 10px;
+}
+
+@media (max-width: 768px) {
+    .overview-grid {
+        grid-template-columns: repeat(8, 1fr);
+        gap: 6px;
+    }
+}
+
+@media (max-width: 480px) {
+    .overview-grid {
+        grid-template-columns: repeat(5, 1fr);
+        gap: 5px;
+    }
+    .tab-button {
+        padding: 10px 20px;
+        font-size: 1rem;
+    }
+}
+
 /* アニメーション */
 @keyframes numberAppear {
     0% {

--- a/style.css
+++ b/style.css
@@ -14,29 +14,28 @@ body {
 .container {
     max-width: 1600px;
     margin: 0 auto;
-    padding: 30px;
-    min-height: 100vh;
+    padding: 16px 30px;
+    height: 100vh;
     display: flex;
     flex-direction: column;
 }
 
 header {
-    text-align: center;
-    margin-bottom: 50px;
-    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    margin-bottom: 20px;
 }
 
 header h1 {
     color: white;
-    font-size: 3.5rem;
+    font-size: clamp(1.8rem, 3vw, 3.5rem);
     text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-    margin-bottom: 15px;
+    text-align: center;
 }
 
 .settings-button {
-    position: absolute;
-    top: 0;
-    right: 0;
+    justify-self: end;
     background: rgba(255, 255, 255, 0.2);
     color: white;
     border: 2px solid rgba(255, 255, 255, 0.3);
@@ -56,38 +55,42 @@ header h1 {
 
 main {
     display: flex;
-    gap: 50px;
+    gap: 30px;
     flex: 1;
+    min-height: 0;
 }
 
 .lottery-area {
     flex: 0 0 30%;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: stretch;
 }
 
 .current-number {
     text-align: center;
     background: white;
-    padding: 50px;
+    padding: 24px;
     border-radius: 25px;
     box-shadow: 0 15px 40px rgba(0,0,0,0.2);
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
 .current-number h2 {
     color: #667eea;
-    margin-bottom: 30px;
-    font-size: 2rem;
+    margin-bottom: 16px;
+    font-size: clamp(1.2rem, 2vw, 2rem);
 }
 
 .number-display {
-    font-size: 20rem;
+    font-size: clamp(4rem, 12vw, 14rem);
     font-weight: bold;
     color: #764ba2;
-    margin: 40px 0;
-    min-height: 100px;
+    margin: 16px 0;
+    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -123,18 +126,19 @@ main {
 .history-area {
     flex: 0 0 70%;
     background: white;
-    padding: 40px;
+    padding: 24px 30px;
     border-radius: 25px;
     box-shadow: 0 15px 40px rgba(0,0,0,0.2);
-    max-height: 800px;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 .history-area h2 {
     color: #667eea;
-    margin-bottom: 30px;
+    margin-bottom: 16px;
     text-align: center;
-    font-size: 2rem;
+    font-size: clamp(1.2rem, 2vw, 2rem);
 }
 
 .history-list {
@@ -193,28 +197,28 @@ main {
 
 footer {
     text-align: center;
-    margin-top: 50px;
+    margin-top: 12px;
     color: white;
     opacity: 0.8;
-    font-size: 1.1rem;
+    font-size: 1rem;
 }
 
 /* タブ */
 .view-tabs {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 12px;
-    margin-bottom: 30px;
 }
 
 .tab-button {
     background: rgba(255, 255, 255, 0.2);
     color: white;
     border: 2px solid rgba(255, 255, 255, 0.3);
-    padding: 12px 36px;
+    padding: 12px 24px;
     border-radius: 25px;
     cursor: pointer;
     font-size: 1.2rem;
+    white-space: nowrap;
     transition: all 0.3s ease;
     backdrop-filter: blur(10px);
 }
@@ -245,24 +249,26 @@ footer {
 .overview-area {
     flex: 1;
     background: white;
-    padding: 40px;
+    padding: 24px 30px;
     border-radius: 25px;
     box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+    display: flex;
+    flex-direction: column;
 }
 
 .overview-area h2 {
     color: #667eea;
     text-align: center;
-    font-size: 2rem;
-    margin-bottom: 12px;
+    font-size: clamp(1.2rem, 2vw, 2rem);
+    margin-bottom: 6px;
 }
 
 .overview-stats {
     text-align: center;
     color: #764ba2;
-    font-size: 1.2rem;
+    font-size: 1.1rem;
     font-weight: bold;
-    margin-bottom: 30px;
+    margin-bottom: 12px;
 }
 
 .overview-grid {

--- a/style.css
+++ b/style.css
@@ -267,8 +267,8 @@ footer {
 
 .overview-grid {
     display: grid;
-    grid-template-columns: repeat(10, 1fr);
-    gap: 10px;
+    grid-template-columns: repeat(15, 1fr);
+    gap: 8px;
     margin-bottom: 30px;
 }
 
@@ -278,7 +278,7 @@ footer {
     align-items: center;
     justify-content: center;
     border-radius: 12px;
-    font-size: clamp(1rem, 2vw, 1.6rem);
+    font-size: clamp(1rem, 3.5vw, 2.4rem);
     font-weight: bold;
     background: #f0f0f0;
     color: #555;


### PR DESCRIPTION
## 概要

Issue #2 に基づき、01〜75 の全番号を俯瞰できる「全体画面」と、履歴画面との切替タブを実装しました。

## 変更内容

### 機能追加
- **全体画面**：01〜75 の全番号を 15列×5行 のグリッドで表示
  - 抽選済み番号は紫色でハイライト
  - 最新の抽選番号はピンク色で強調表示
  - 「抽選済み：N / 75」のカウンターを表示
- **画面切替タブ**：「履歴画面」「全体画面」をタブで切替
  - 切替は CSS の `display: none` で制御し、抽選状態（`drawnNumbers`）は保持されたまま
  - 全体画面にもリセットボタンを配置

### レイアウト改善
- タブをヘッダー左上に移動（ヘッダーを「タブ / タイトル / 設定」の3カラム grid に変更）
- 横長画面（4:3・16:9）で縦方向に1画面に収まるよう各部のサイズ・余白を調整
  - `container` を `height: 100vh` に変更
  - `font-size` を `clamp()` ベースのレスポンシブ値に変更
  - `padding` / `margin` / `gap` を縮小

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `index.html` | タブUI、全体画面パネルのHTML追加、タブをheader内に移動 |
| `script.js` | `switchTab()` / `buildOverviewGrid()` / `updateOverviewGrid()` メソッド追加 |
| `style.css` | タブ・グリッド・ハイライトスタイル追加、縦方向コンパクト化 |

## 受け入れ基準の確認

- [x] 01〜75 の全番号が全体画面にグリッド表示される
- [x] 抽選済み番号が未抽選と視覚的に区別できる
- [x] 履歴画面 ↔ 全体画面の切替ができる
- [x] 切替しても抽選結果（`drawnNumbers`）が失われない
- [x] 全体画面表示中に抽選した番号がリアルタイムで反映される
- [x] リセットボタンを押すと全体画面の表示も初期化される

## レビュワーへ

- `localStorage` による永続化は既存ロジックをそのまま使用しています
- 既存の「履歴画面」の UI・動作に変更はありません